### PR TITLE
Recoverable[IO] should catch NonFatal

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,15 +5,13 @@ lazy val effect = project.in(file("."))
 
 lazy val core = module("core")
 
-lazy val scalazV = "7.2.15"
-
 lazy val scalaz7 = module("scalaz7")
   .dependsOn(core)
   .settings(
     libraryDependencies ++= Seq(
-      "org.scalaz" %% "scalaz-concurrent" % scalazV,
-      "org.scalaz" %% "scalaz-core" % scalazV
-    )
+      "org.scalaz" %% "scalaz-concurrent",
+      "org.scalaz" %% "scalaz-core"
+    ).map(_ % "7.2.15")
   )
 
 lazy val defaultScalacOptions = scalacOptions ++= Seq(

--- a/scalaz7/src/main/scala/io/estatico/effect/instances/ScalazDefaultRecoverable.scala
+++ b/scalaz7/src/main/scala/io/estatico/effect/instances/ScalazDefaultRecoverable.scala
@@ -1,0 +1,32 @@
+package io.estatico.effect
+package instances
+
+object ScalazDefaultRecoverable {
+
+  /** Default implementation for types which support Functor. */
+  abstract class FromFunctor[F[_]](
+    implicit protected val F: scalaz.Functor[F]
+  ) extends Recoverable[F] {
+
+    override def attemptFold[A, B](fa: F[A])(f: Throwable => B, g: A => B): F[B]
+      = F.map(attempt(fa))(_.fold(f, g))
+
+    override def transform[A, B](fa: F[A])(f: Throwable => Throwable, g: A => B): F[B]
+      = F.map(failMap(fa)(f))(g)
+  }
+
+  /** Default implementation for types which support Monad. */
+  abstract class FromMonad[F[_]](
+    implicit override protected val F: scalaz.Monad[F]
+  ) extends FromFunctor[F] {
+
+    override def attemptFoldWith[A, B](fa: F[A])(f: Throwable => F[B], g: A => F[B]): F[B]
+      = F.bind(attempt(fa))(_.fold(f, g))
+
+    override def handleWith[A](fa: F[A])(f: PartialFunction[Throwable, F[A]]): F[A]
+      = F.join(handle(F.point(fa))(f))
+
+    override def mergeEither[A](fa: F[Either[Throwable, A]]): F[A]
+      = F.bind(fa)(fromEither)
+  }
+}

--- a/scalaz7/src/main/scala/io/estatico/effect/instances/ScalazIOInstances.scala
+++ b/scalaz7/src/main/scala/io/estatico/effect/instances/ScalazIOInstances.scala
@@ -1,6 +1,7 @@
 package io.estatico.effect
 package instances
 
+import scala.util.control.NonFatal
 import scalaz.effect._
 
 object ScalazIOInstances extends ScalazTaskInstances
@@ -8,42 +9,31 @@ object ScalazIOInstances extends ScalazTaskInstances
 trait ScalazIOInstances {
 
   /** Default instance for Recoverable[IO] */
-  implicit val recoverableIO: Recoverable[IO] = new Recoverable[IO] {
+  implicit val recoverableIO: Recoverable[IO] = new ScalazDefaultRecoverable.FromMonad[IO] {
 
-    override def mergeEither[A](fa: IO[Either[Throwable, A]]): IO[A] =
-      fa.flatMap(_.fold(IO.throwIO(_), IO(_)))
+    override def fromEither[A](either: Either[Throwable, A]): IO[A]
+      = either.fold(IO.throwIO, IO(_))
 
-    override def attemptFoldWith[A, B](fa: IO[A])(f: (Throwable) => IO[B], g: (A) => IO[B]): IO[B] =
-      fa.catchLeft.flatMap(_.fold(f, g))
+    override def fail[A](e: Throwable): IO[A] = IO.throwIO(e)
 
-    override def failMap[A](fa: IO[A])(f: (Throwable) => Throwable): IO[A] =
-      fa.except{err => IO.throwIO(f(err))}
+    override def attempt[A](fa: IO[A]): IO[Either[Throwable, A]]
+      = nonFatal(fa.map(Right(_): Either[Throwable, A]))(e => IO(Left(e)))
 
-    override def handle[A](fa: IO[A])(f: PartialFunction[Throwable, A]): IO[A] =
-      fa.except(err => IO(f(err)))
+    override def handle[A](fa: IO[A])(f: PartialFunction[Throwable, A]): IO[A]
+      = nonFatal(fa)(e => IO(f.applyOrElse(e, throw e)))
 
-    override def fromEither[A](either: Either[Throwable, A]): IO[A] =
-      mergeEither(IO(either))
+    override def failMap[A](fa: IO[A])(f: Throwable => Throwable): IO[A]
+      = nonFatal(fa)(e => IO.throwIO(f(e)))
 
-    override def attempt[A](fa: IO[A]): IO[Either[Throwable, A]] =
-      fa.catchLeft.map(_.toEither)
-
-    override def fail[A](e: Throwable): IO[A] =
-      IO.throwIO(e)
-
-    override def transform[A, B](fa: IO[A])(f: (Throwable) => Throwable, g: (A) => B): IO[B] =
-      failMap(fa)(f).map(g)
-
-    override def handleWith[A](fa: IO[A])(f: PartialFunction[Throwable, IO[A]]): IO[A] =
-      fa.except(f)
-
-    override def attemptFold[A, B](fa: IO[A])(f: (Throwable) => B, g: (A) => B): IO[B] =
-      fa.catchLeft.map(_.fold(f, g))
+    /** Similar to IO#except, but catches NonFatal instead of Throwable. */
+    private def nonFatal[A](fa: IO[A])(f: Throwable => IO[A]): IO[A] = fa.except {
+      case NonFatal(e) => f(e)
+      case e => IO.throwIO(e)
+    }
   }
 
   /** Default instance for Sync[IO] */
   implicit val syncIO: Sync[IO] = new Sync[IO] {
-
     override def sync[A](a: A): IO[A] = IO(a)
   }
 }


### PR DESCRIPTION
The `IO#except` method catches all Throwables, so instead we should explicitly catch `NonFatal`. There are some other things that became apparent when looking at this, so I think `Recoverable` needs some laws.  I'll try to get those worked out and merged in and hopefully get a 0.0.1 release out today.